### PR TITLE
Use rehosted version from Azure, which includes the MD5 header

### DIFF
--- a/config.js
+++ b/config.js
@@ -146,7 +146,7 @@ const dem = [
   { id: 'waltti', url: 'https://elevdata.blob.core.windows.net/elevation/waltti/waltti-10m-elevation-model.tif' },
   { id: 'hsl', url: 'https://elevdata.blob.core.windows.net/elevation/hsl/hsl-10m-elevation-model.tif' },
   // extracted and rehosted; originally from http://srtm.csi.cgiar.org/wp-content/uploads/files/srtm_5x5/TIFF/srtm_38_03.zip
-  { id: 'hb', url: 'https://leonard.io/herrenberg/srtm_38_03.tif' },
+  { id: 'hb', url: 'https://herrenberg.blob.core.windows.net/herrenberg-elevation/srtm_38_03.tif' },
 ]
 
 const constants = {

--- a/task/DownloadDEMBlob.js
+++ b/task/DownloadDEMBlob.js
@@ -21,9 +21,7 @@ const compareHashes = (headerHash, localFilePath) => {
     })
     s.on('end', function () {
       var fileHash = shasum.digest('base64')
-      // hardcoded because the server doesn't send it
-      console.log(fileHash);
-      if (fileHash === "VCQnNJ+LV3GYCrwhRCQezQ==") {
+      if (fileHash === headerHash) {
         resolve(true)
       } else {
         reject('end') // eslint-disable-line


### PR DESCRIPTION
I created an Azure account and uploaded the files there.

Sadly, the Content-MD5 header is not calculated by default but you have to add it manually.

```
az storage blob upload \
   --connection-string "<connection-string-including-credentials>" \
   --container-name herrenberg-elevation \
   --name srtm_38_03.tif \
   --file srtm_38_03.tif \
   --content-md5 `cat srtm_38_03.tif | openssl dgst -md5 -binary | base64`
```

 