### PR TITLE
Prune unreachable islands more aggressively

### DIFF
--- a/router-hb/build-config.json
+++ b/router-hb/build-config.json
@@ -1,5 +1,6 @@
 {
   "areaVisibility": true,
   "parentStopLinking": true,
-  "osmWayPropertySet": "default"
+  "osmWayPropertySet": "default",
+  "islandWithoutStopsMaxSize": 1000
 }


### PR DESCRIPTION
If an island will only be preserved if there are more than 1000 nodes in it.