### PR TITLE
Add anonymised mfdz carpool feed

### DIFF
--- a/config.js
+++ b/config.js
@@ -13,7 +13,8 @@ const HB_CONFIG = {
     src('vvs', 'https://gtfs.mfdz.de/gtfs/VVS.with-shapes.gtfs.zip', false, ['router-hb/gtfs-rules/vvs.rule']),
     src('naldo', 'https://www.nvbw.de/fileadmin/nvbw/open-data/Fahrplandaten_mit_Liniennetz/naldo.zip', false, []),
     src('vgc', 'https://www.nvbw.de/fileadmin/nvbw/open-data/Fahrplandaten_mit_Liniennetz/vgc.zip', false, []),
-    src('vgf', 'https://www.nvbw.de/fileadmin/nvbw/open-data/Fahrplandaten_mit_Liniennetz/vgf.zip', false, [])
+    src('vgf', 'https://www.nvbw.de/fileadmin/nvbw/open-data/Fahrplandaten_mit_Liniennetz/vgf.zip', false, []),
+    src('mfdz', 'https://herrenberg.blob.core.windows.net/herrenberg-elevation/mfdz-anonymized.gtfs.zip', false, [])
   ],
   'osm': 'hb',
   'dem': 'hb'


### PR DESCRIPTION
In order to get started with the development quickly I took @hbruch's feed and replaced all the URLs to the carpooling offers with a single static one.

This means that this feed contains no personally identifiable information.